### PR TITLE
Removed deprecated arguments in main.py

### DIFF
--- a/neuralintents/main.py
+++ b/neuralintents/main.py
@@ -106,7 +106,7 @@ class GenericAssistant(IAssistant):
         self.model.add(Dropout(0.5))
         self.model.add(Dense(len(train_y[0]), activation='softmax'))
 
-        sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+        sgd = SGD(learning_rate=0.01, nesterov=True)
         self.model.compile(loss='categorical_crossentropy', optimizer=sgd, metrics=['accuracy'])
 
         self.hist = self.model.fit(np.array(train_x), np.array(train_y), epochs=200, batch_size=5, verbose=1)


### PR DESCRIPTION
line 109: Decay argument has been deprecated for all optimizers since Keras 2.3. For lr decay, changed to learning_rate instead.